### PR TITLE
Exclude status.css from list of availabe style sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.project

--- a/lib/BPView/Config.pm
+++ b/lib/BPView/Config.pm
@@ -507,9 +507,10 @@ sub get_css {
   # get list of css files
   opendir (CSSDIR, $dir) or croak ("Can't open directory $dir }: $!");
   while (my $file = readdir (CSSDIR)){
-	next unless $file =~ /\.css$/;
-	$file =~ s/.css$//;
-	push @{ $css_files }, $file;
+	  next unless $file =~ /\.css$/;
+	  next if $file =~ /^status.css$/;
+	  $file =~ s/.css$//;
+	  push @{ $css_files }, $file;
   }
   closedir (CSSDIR);
   


### PR DESCRIPTION
This commit excludes status.css from list of availabel style sheets